### PR TITLE
Pull Request Double Testing Fix

### DIFF
--- a/.github/workflows/liatriotests.yml
+++ b/.github/workflows/liatriotests.yml
@@ -19,6 +19,9 @@ env:
   PORT: 80
 jobs:
   liatriotests: # Name Required for passing the pull request checks
+    permissions:
+      contents: read
+      packages: read
     if: github.event_name == 'push' && github.event.pull_request == null
     # build:
     # Runner using version

--- a/.github/workflows/liatriotests.yml
+++ b/.github/workflows/liatriotests.yml
@@ -19,6 +19,7 @@ env:
   PORT: 80
 jobs:
   liatriotests: # Name Required for passing the pull request checks
+    if: github.event_name == 'push' && github.event.pull_request == null
     # build:
     # Runner using version
     runs-on: ubuntu-24.04


### PR DESCRIPTION
During pull request, the tests were running twice causing issues. Current setup deletes the pods after a bit of time to reduce costs.