### PR TITLE
Kubernetes: RBAC Testing

### DIFF
--- a/.github/workflows/liatriotests.yml
+++ b/.github/workflows/liatriotests.yml
@@ -20,7 +20,7 @@ env:
   DOCKER_REPO: apptemp/liatrio
   PORT: 80
 jobs:
-  liatriotests: # Name Required for passing the pull request checks
+  liatriotests: # Name Required for passing the pull request  checks
     permissions:
       contents: read
       packages: read

--- a/SetupFiles/Notes.txt
+++ b/SetupFiles/Notes.txt
@@ -37,4 +37,6 @@ kubectl get pods -n dev
 Service accounts
 kubectl get serviceaccounts --all-namespaces
 kubectl get serviceaccount github-actions-sa-user -n github-actions -o yaml
+kubectl get clusterrolebinding --field-selector=subjects.name=github-actions-sa-user
 
+used for testing

--- a/k8s/rbac.yaml
+++ b/k8s/rbac.yaml
@@ -18,21 +18,21 @@ kind: ServiceAccount
 metadata:
   name: github-actions-sa-user
   namespace: github-actions
----
+# ---
 # Rolebinding
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: user-reader-dev_staging_prod-dev
-  namespace: dev
-subjects:
-  - kind: ServiceAccount
-    name: github-actions-sa-user
-    namespace: github-actions
-roleRef:
-  kind: ClusterRole
-  name: user-reader-dev_staging_prod
-  apiGroup: rbac.authorization.k8s.io
+# apiVersion: rbac.authorization.k8s.io/v1
+# kind: RoleBinding
+# metadata:
+#   name: user-reader-dev_staging_prod-dev
+#   namespace: dev
+# subjects:
+#   - kind: ServiceAccount
+#     name: github-actions-sa-user
+#     namespace: github-actions
+# roleRef:
+#   kind: ClusterRole
+#   name: user-reader-dev_staging_prod
+#   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/k8s/rbac.yaml
+++ b/k8s/rbac.yaml
@@ -21,33 +21,33 @@ metadata:
 ---
 # Rolebinding
 
-# apiVersion: rbac.authorization.k8s.io/v1
-# kind: RoleBinding
-# metadata:
-#   name: user-reader-dev_staging_prod-dev
-#   namespace: dev
-# subjects:
-#   - kind: ServiceAccount
-#     name: github-actions-sa-user
-#     namespace: github-actions
-# roleRef:
-#   kind: ClusterRole
-#   name: user-reader-dev_staging_prod
-#   apiGroup: rbac.authorization.k8s.io
-# ---
-# apiVersion: rbac.authorization.k8s.io/v1
-# kind: RoleBinding
-# metadata:
-#   name: user-reader-dev_staging_prod-staging
-#   namespace: staging
-# subjects:
-#   - kind: ServiceAccount
-#     name: github-actions-sa-user
-#     namespace: github-actions
-# roleRef:
-#   kind: ClusterRole
-#   name: user-reader-dev_staging_prod
-#   apiGroup: rbac.authorization.k8s.io
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: user-reader-dev_staging_prod-dev
+  namespace: dev
+subjects:
+  - kind: ServiceAccount
+    name: github-actions-sa-user
+    namespace: github-actions
+roleRef:
+  kind: ClusterRole
+  name: user-reader-dev_staging_prod
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: user-reader-dev_staging_prod-staging
+  namespace: staging
+subjects:
+  - kind: ServiceAccount
+    name: github-actions-sa-user
+    namespace: github-actions
+roleRef:
+  kind: ClusterRole
+  name: user-reader-dev_staging_prod
+  apiGroup: rbac.authorization.k8s.io
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/k8s/rbac.yaml
+++ b/k8s/rbac.yaml
@@ -33,32 +33,32 @@ metadata:
 #   kind: ClusterRole
 #   name: user-reader-dev_staging_prod
 #   apiGroup: rbac.authorization.k8s.io
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: user-reader-dev_staging_prod-staging
-  namespace: staging
-subjects:
-  - kind: ServiceAccount
-    name: github-actions-sa-user
-    namespace: github-actions
-roleRef:
-  kind: ClusterRole
-  name: user-reader-dev_staging_prod
-  apiGroup: rbac.authorization.k8s.io
+# ---
+# apiVersion: rbac.authorization.k8s.io/v1
+# kind: RoleBinding
+# metadata:
+#   name: user-reader-dev_staging_prod-staging
+#   namespace: staging
+# subjects:
+#   - kind: ServiceAccount
+#     name: github-actions-sa-user
+#     namespace: github-actions
+# roleRef:
+#   kind: ClusterRole
+#   name: user-reader-dev_staging_prod
+#   apiGroup: rbac.authorization.k8s.io
 
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: user-reader-dev_staging_prod-prod
-  namespace: prod
-subjects:
-  - kind: ServiceAccount
-    name: github-actions-sa-user
-    namespace: github-actions
-roleRef:
-  kind: ClusterRole
-  name: user-reader-dev_staging_prod
-  apiGroup: rbac.authorization.k8s.io
+# ---
+# apiVersion: rbac.authorization.k8s.io/v1
+# kind: RoleBinding
+# metadata:
+#   name: user-reader-dev_staging_prod-prod
+#   namespace: prod
+# subjects:
+#   - kind: ServiceAccount
+#     name: github-actions-sa-user
+#     namespace: github-actions
+# roleRef:
+#   kind: ClusterRole
+#   name: user-reader-dev_staging_prod
+#   apiGroup: rbac.authorization.k8s.io

--- a/k8s/rbac.yaml
+++ b/k8s/rbac.yaml
@@ -18,8 +18,9 @@ kind: ServiceAccount
 metadata:
   name: github-actions-sa-user
   namespace: github-actions
-# ---
+---
 # Rolebinding
+
 # apiVersion: rbac.authorization.k8s.io/v1
 # kind: RoleBinding
 # metadata:
@@ -48,17 +49,17 @@ metadata:
 #   name: user-reader-dev_staging_prod
 #   apiGroup: rbac.authorization.k8s.io
 
-# ---
-# apiVersion: rbac.authorization.k8s.io/v1
-# kind: RoleBinding
-# metadata:
-#   name: user-reader-dev_staging_prod-prod
-#   namespace: prod
-# subjects:
-#   - kind: ServiceAccount
-#     name: github-actions-sa-user
-#     namespace: github-actions
-# roleRef:
-#   kind: ClusterRole
-#   name: user-reader-dev_staging_prod
-#   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: user-reader-dev_staging_prod-prod
+  namespace: prod
+subjects:
+  - kind: ServiceAccount
+    name: github-actions-sa-user
+    namespace: github-actions
+roleRef:
+  kind: ClusterRole
+  name: user-reader-dev_staging_prod
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Confirmed that ClusterRole was not giving permissions to every namespace as long as ClusterBinding was not used.